### PR TITLE
independent coroutine scope

### DIFF
--- a/app/src/main/java/ke/co/appslab/androidpagingwithcoroutines/repositories/PostsDataSource.kt
+++ b/app/src/main/java/ke/co/appslab/androidpagingwithcoroutines/repositories/PostsDataSource.kt
@@ -6,12 +6,16 @@ import ke.co.appslab.androidpagingwithcoroutines.models.RedditPost
 import ke.co.appslab.androidpagingwithcoroutines.networking.ApiClient
 import ke.co.appslab.androidpagingwithcoroutines.networking.ApiService
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
 
-class PostsDataSource(private val scope: CoroutineScope) :
+class PostsDataSource(coroutineContext: CoroutineContext) :
     PageKeyedDataSource<String, RedditPost>() {
     private val apiService = ApiClient.getClient().create(ApiService::class.java)
+
+    private val job = Job()
+    private val scope = CoroutineScope(coroutineContext + job)
 
     override fun loadInitial(params: LoadInitialParams<String>, callback: LoadInitialCallback<String, RedditPost>) {
         scope.launch {
@@ -75,7 +79,7 @@ class PostsDataSource(private val scope: CoroutineScope) :
 
     override fun invalidate() {
         super.invalidate()
-        scope.cancel()
+        job.cancel()
     }
 
 }

--- a/app/src/main/java/ke/co/appslab/androidpagingwithcoroutines/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/ke/co/appslab/androidpagingwithcoroutines/viewmodels/MainViewModel.kt
@@ -2,12 +2,12 @@ package ke.co.appslab.androidpagingwithcoroutines.viewmodels
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import androidx.paging.DataSource
 import androidx.paging.LivePagedListBuilder
 import androidx.paging.PagedList
 import ke.co.appslab.androidpagingwithcoroutines.models.RedditPost
 import ke.co.appslab.androidpagingwithcoroutines.repositories.PostsDataSource
+import kotlinx.coroutines.Dispatchers
 
 class MainViewModel : ViewModel() {
     var postsLiveData  :LiveData<PagedList<RedditPost>>
@@ -27,7 +27,7 @@ class MainViewModel : ViewModel() {
 
         val dataSourceFactory = object : DataSource.Factory<String, RedditPost>() {
             override fun create(): DataSource<String, RedditPost> {
-                return PostsDataSource(viewModelScope)
+                return PostsDataSource(Dispatchers.IO)
             }
         }
         return LivePagedListBuilder<String, RedditPost>(dataSourceFactory, config)


### PR DESCRIPTION
in previous version, by calling datasource "invalidate()" method (for example: refresh use case) all of viewmodel coroutines will cancel because both datasource and viewmodel are using the same coroutine scope.